### PR TITLE
Omit extra html tags.

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -66,10 +66,9 @@ renderPage page = renderHtml $ H.html $ do
     H.toMarkup page
 
 displayDBItem :: DBItem -> H.Html
-displayDBItem (DBItem {ditem_title, dretail_price, dsku}) = H.html $ do
-  H.tr $ do
-    H.td $ H.a H.! A.href (productUrl dsku) H.! A.target "_blank" $ H.toHtml ditem_title
-    H.td $ H.toHtml dretail_price
+displayDBItem (DBItem {ditem_title, dretail_price, dsku}) = H.tr $ do
+  H.td $ H.a H.! A.href (productUrl dsku) H.! A.target "_blank" $ H.toHtml ditem_title
+  H.td $ H.toHtml dretail_price
 
 displayPriceChange :: PriceChange -> H.Html
 displayPriceChange (PriceChange {pitem_title, pbefore_price, pafter_price, pafter_date, psku}) = H.html $ do


### PR DESCRIPTION
Each table row in the output is wrapped in html tags.
```
    ...
    <html>
    <tr>
      <td><a href="https://traderjoes.com/home/products/pdp/020429" target="_blank">Spanish Manzanilla Olives with
          Pimento Paste</a></td>
      <td>2.99</td>
    </tr>

    </html>
    <html>
    <tr>
      <td><a href="https://traderjoes.com/home/products/pdp/020487" target="_blank">Panettone</a></td>
      <td>6.99</td>
    </tr>

    </html>
    ...
```

This change omits those extra tags. E.g.:
```
    ...
    <tr>
      <td><a href="https://traderjoes.com/home/products/pdp/020429" target="_blank">Spanish Manzanilla Olives with
          Pimento Paste</a></td>
      <td>2.99</td>
    </tr>
    <tr>
      <td><a href="https://traderjoes.com/home/products/pdp/020487" target="_blank">Panettone</a></td>
      <td>6.99</td>
    </tr>
    ...
```
