### PR TITLE
Verify site directory existence prior to deletion.

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -14,7 +14,7 @@ import Data.Time (getCurrentTime, getCurrentTimeZone, utcToLocalTime)
 import Database.SQLite.Simple qualified as SQL
 import GHC.Generics
 import Prices (Item (..), allItems)
-import System.Directory (createDirectory, removeDirectoryRecursive)
+import System.Directory (createDirectory, doesDirectoryExist, removeDirectoryRecursive)
 import System.Environment (getArgs)
 import System.IO
 import Text.Blaze.Html.Renderer.Utf8 (renderHtml)
@@ -48,8 +48,7 @@ main = do
             H.table H.! A.class_ "table table-striped table-gray" $ do
               H.thead . H.tr . H.toMarkup $ H.th <$> (H.toMarkup <$> ["Item Name" :: String, "Retail Price"])
               H.toMarkup $ displayDBItem <$> prices
-      removeDirectoryRecursive "site"
-      createDirectory "site"
+      setupSiteDirectory
       L.writeFile "site/index.html" html
     Just "fetch" -> do
       hPutStrLn stderr "running"
@@ -145,3 +144,10 @@ showTime = do
 -- | this should be patched upstream in Blaze
 download :: H.AttributeValue -> H.Attribute
 download = A.attribute "download" " download=\""
+
+-- | create an empty site directory, deleting it beforehand if it already exists
+setupSiteDirectory :: IO ()
+setupSiteDirectory = do
+  siteDirectoryExists <- doesDirectoryExist "site"
+  when siteDirectoryExists $ removeDirectoryRecursive "site"
+  createDirectory "site"


### PR DESCRIPTION
This change improves developer experience.

Explanation: Since Git doesn't support empty directories, the site directory doesn't exist when the repository is newly cloned. Running the gen step without the site directory present produces the following error, at least for me on macOS, causing the gen step to fail.

```
traderjoes: site: removeDirectoryRecursive:getSymbolicLinkStatus: does not exist (No such file or directory)
```

Solution: There are multiple approaches to solving this, e.g. by using a .gitkeep file. This particular change works by attempting site directory deletion if and only if the site directory already exists.