### PR TITLE
fix: add user-agent to fix 403

### DIFF
--- a/Prices.hs
+++ b/Prices.hs
@@ -95,6 +95,7 @@ headers =
   , ("content-type", "application/json")
   , ("pragma", "no-cache")
   , ("accept-encoding", "gzip, deflate, br")
+  , ("user-agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36")
   , ("sec-ch-ua", "\"Not_A Brand\";v=\"8\", \"Chromium\";v=\"120\", \"Google Chrome\";v=\"120\"")
   , ("sec-ch-ua-mobile", "?0")
   , ("sec-ch-ua-platform", "\"macOS\"")


### PR DESCRIPTION
closes #13

Any user agent seems to work for now, but for realism and consistency I have the latest Chrome on macOS

---

By the way, I'm not a Haskell person, when I run directly from Nix everything seems fine, but when I run from source I have to make a new connection manager to change `supportedExtendedMainSecret`, is that supposed to happen?